### PR TITLE
快捷键打开FGUI编辑器 以及工程

### DIFF
--- a/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs
+++ b/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs
@@ -68,7 +68,7 @@ namespace ET
         [MenuItem("Tools/打开FGUI编辑器 %#_e",false,0)]
         public static void OpenUiEditor()
         {
-            DoBat("../../FGUIProject/FairyGUI-Editor/FairyGUI-Editor.exe", "../../FGUIProject/REGame/REGame.fairy");
+            DoBat("../../FGUIProject/FairyGUI-Editor/FairyGUI-Editor.exe", "../../FGUIProject/FGUI_ET/FGUI_ET.fairy");
         }
         
     }

--- a/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs
+++ b/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Diagnostics;
+using UnityEditor;
+using UnityEngine;
+
+namespace ET
+{
+    /// <summary>
+    /// 快捷键打开FGUI编辑器 以及工程
+    /// </summary>
+    public static class FguiEditorTool
+    {
+        private static string GetProjPath(string relativePath = "")
+        {
+            if (relativePath == null)
+            {
+                relativePath = "";
+            }
+
+            relativePath = relativePath.Trim();
+            if (!string.IsNullOrEmpty(relativePath))
+            {
+                if (relativePath.Contains("\\"))
+                {
+                    relativePath = relativePath.Replace("\\", "/");
+                }
+
+                if (!relativePath.StartsWith("/"))
+                {
+                    relativePath = "/" + relativePath;
+                }
+            }
+
+            return Application.dataPath + relativePath;
+        }
+        
+        private static void OpenFileOrFolder(string path)
+        {
+            Process.Start("explorer.exe", path.Replace("/", "\\"));
+        }
+        
+        
+        private static void DoBat(string path, string param = null, string openFolder = null)
+        {
+            try
+            {
+                if (string.IsNullOrEmpty(param))
+                {
+                    Process.Start(GetProjPath(path));
+                }
+                else
+                {
+                    Process.Start(GetProjPath(path), GetProjPath(param));
+                }
+
+                if (openFolder != null)
+                {
+                    OpenFileOrFolder(GetProjPath(openFolder));
+                }
+            }
+            catch (Exception ex)
+            {
+                UnityEngine.Debug.Log(ex.ToString());
+            }
+        }
+
+        
+        [MenuItem("Tools/打开FGUI编辑器 %#_e",false,0)]
+        public static void OpenUiEditor()
+        {
+            DoBat("../../FGUIProject/FairyGUI-Editor/FairyGUI-Editor.exe", "../../FGUIProject/REGame/REGame.fairy");
+        }
+        
+    }
+}

--- a/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs.meta
+++ b/Unity/Assets/Editor/ToolEditor/FguiEditorTool.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ec1dc2f7d7d31ca478502d5952d2df72
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
每次打开FGUI编辑器都比较麻烦 在Unity里面增加了一个快捷键 可以打开内置的FGUI编辑器
其实第二个参数还可以直接打开工程的 我不知道为什么这下就不行了...